### PR TITLE
Validate hex string length

### DIFF
--- a/MchatTests/Protocol/BinaryEncodingUtilsTests.swift
+++ b/MchatTests/Protocol/BinaryEncodingUtilsTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import chatM
+
+final class BinaryEncodingUtilsTests: XCTestCase {
+    func testHexInitFailsOnOddLength() {
+        XCTAssertNil(Data(hexString: "ABC"))
+    }
+
+    func testHexInitParsesValidString() {
+        let data = Data(hexString: "0a0b")
+        XCTAssertEqual(data, Data([0x0a, 0x0b]))
+    }
+}

--- a/bitchat/Protocols/BinaryEncodingUtils.swift
+++ b/bitchat/Protocols/BinaryEncodingUtils.swift
@@ -18,10 +18,11 @@ extension Data {
     }
     
     init?(hexString: String) {
+        guard hexString.count % 2 == 0 else { return nil }
         let len = hexString.count / 2
         var data = Data(capacity: len)
         var index = hexString.startIndex
-        
+
         for _ in 0..<len {
             let nextIndex = hexString.index(index, offsetBy: 2)
             guard let byte = UInt8(String(hexString[index..<nextIndex]), radix: 16) else {
@@ -30,7 +31,7 @@ extension Data {
             data.append(byte)
             index = nextIndex
         }
-        
+
         self = data
     }
 }


### PR DESCRIPTION
## Summary
- avoid silently truncating odd-length hex strings
- test hex string decoding

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68a745c7e95c8320a55fc9b617dcf680